### PR TITLE
Revise Dockerfile

### DIFF
--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/all-spark-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/all-spark-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/all-spark-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/all-spark-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/base-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/base-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/base-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/base-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/datascience-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/datascience-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/datascience-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/datascience-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/minimal-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/minimal-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/minimal-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/minimal-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/pyspark-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/pyspark-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/pyspark-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/pyspark-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/r-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/r-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/r-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/r-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/scipy-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/scipy-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/scipy-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/scipy-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM jupyter/tensorflow-notebook:latest
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="jupyter/tensorflow-notebook:latest" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -34,12 +34,18 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-# add the script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+# add a script that starts HTCondor before the notebook runs
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
-RUN pip install --no-cache htcondor htchirp htmap
+RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="jupyter/tensorflow-notebook:latest"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="jupyter/tensorflow-notebook:latest" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add the script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache htcondor htchirp htmap

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -16,23 +16,16 @@ LABEL maintainer="chtc@cs.wisc.edu"
 
 # config
 
-ENV HTMAP_DOCKER_IMAGE="<BASE_IMAGE>"
-ENV HTMAP_DELIVERY_METHOD="assume"
-ARG JUPYTERHUB_VERSION=0.9.4
-ARG HTCONDOR_VERSION=8.8
+ENV HTMAP_DOCKER_IMAGE="<BASE_IMAGE>" \
+    HTMAP_DELIVERY_METHOD="assume" \
+    DEBIAN_FRONTEND=noninteractive
+ARG HTCONDOR_VERSION=8.9
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
 
-# actual build
-
+# install HTCondor, and a few other convenience tools
 USER root
-
-# Install latest HTCondor native package, as well
-# as HTCondor python bindings, htmap package, and
-# a few handy things like vim, less.
-
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq \
  && apt-get install -qq gnupg vim less git \
  && wget -qO - https://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | apt-key add - \
@@ -41,26 +34,12 @@ RUN apt-get update -qq \
  && apt-get clean -qq \
  && rm -rf /var/lib/apt/lists/*
 
-
-USER $NB_UID
-
-# We want the end user to be able to conda install new
-# packages without sudo.  To do this, we need to upgrade
-# the version of Conda to avoid hitting this conda bug:
-# https://github.com/conda/conda/issues/7267
-
-RUN conda config --add channels conda-canary \
- && conda update -n base conda
-
-USER root
-
+# add a script that starts HTCondor before the notebook runs
 COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
-COPY condor_config.local /etc/condor/condor_config.local
 
-RUN mkdir -p /usr/local/bin/before-notebook.d \
-  && pip install --no-cache \
-  jupyterhub==$JUPYTERHUB_VERSION \
-  htcondor \
-  htmap
+# add an optimized HTCondor config
+COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 
+# install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
+RUN pip install --no-cache-dir htcondor htchirp htmap

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -6,23 +6,23 @@
 #
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
-#
 
 FROM <BASE_IMAGE>
 
 # metadata
-
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# config
-
-ENV HTMAP_DOCKER_IMAGE="<BASE_IMAGE>" \
-    HTMAP_DELIVERY_METHOD="assume" \
-    DEBIAN_FRONTEND=noninteractive
+# select HTCondor release series (first two digits only!)
 ARG HTCONDOR_VERSION=8.9
+
+# these are really from the base image, but ARG is not passed to child builds
+# so we need to repeat them here if we want to use them
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_GID="100"
+
+# default to jupyter lab
+ENV JUPYTER_ENABLE_LAB=1
 
 # install HTCondor, and a few other convenience tools
 USER root
@@ -35,7 +35,7 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 # add a script that starts HTCondor before the notebook runs
-COPY start-htcondor.sh /usr/./local/bin/before-notebook.d/
+COPY start-htcondor.sh /usr/local/bin/before-notebook.d/
 
 # add an optimized HTCondor config
 COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
@@ -43,3 +43,9 @@ COPY --chown=jovyan:0 condor_config.local /etc/condor/condor_config.local
 # install HTCondor Python bindings, HTChirp, and HTMap
 USER $NB_UID
 RUN pip install --no-cache-dir htcondor htchirp htmap
+
+# set up environment variable hooks for HTMap settings
+# todo: once HTMap can decide the delivery method itself, remove it from here!
+ENV HTMAP_DELIVERY_METHOD="assume"
+
+# todo: embed image name so HTMap can use the same image for exec


### PR DESCRIPTION
- do not install jupyterhub ourselves, since the base images install it
- install our packages while being the jupyter user, so downstream users can uninstall them
- remove fix for conda issue that doesn't need to be fixed anymore, because it made its way into recent versions of conda
- bump to HTCondor 8.9 series