### PR TITLE
Switch to get.htcondor.org and other tweaks

### DIFF
--- a/BASE_IMAGES.txt
+++ b/BASE_IMAGES.txt
@@ -1,8 +1,8 @@
-jupyter/base-notebook:latest
-jupyter/minimal-notebook:latest
-jupyter/scipy-notebook:latest
-jupyter/r-notebook:latest
-jupyter/tensorflow-notebook:latest
-jupyter/datascience-notebook:latest
-jupyter/pyspark-notebook:latest
-jupyter/all-spark-notebook:latest
+jupyter/base-notebook:ubuntu-20.04
+jupyter/minimal-notebook:ubuntu-20.04
+jupyter/scipy-notebook:ubuntu-20.04
+jupyter/r-notebook:ubuntu-20.04
+jupyter/tensorflow-notebook:ubuntu-20.04
+jupyter/datascience-notebook:ubuntu-20.04
+jupyter/pyspark-notebook:ubuntu-20.04
+jupyter/all-spark-notebook:ubuntu-20.04

--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-all-spark-notebook/Dockerfile
+++ b/notebooks/htc-all-spark-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/all-spark-notebook:latest
+FROM jupyter/all-spark-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-all-spark-notebook/condor_config.local
+++ b/notebooks/htc-all-spark-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-all-spark-notebook/entrypoint.sh
+++ b/notebooks/htc-all-spark-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-base-notebook/Dockerfile
+++ b/notebooks/htc-base-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/base-notebook:latest
+FROM jupyter/base-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-base-notebook/condor_config.local
+++ b/notebooks/htc-base-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-base-notebook/entrypoint.sh
+++ b/notebooks/htc-base-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-datascience-notebook/Dockerfile
+++ b/notebooks/htc-datascience-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/datascience-notebook:latest
+FROM jupyter/datascience-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-datascience-notebook/condor_config.local
+++ b/notebooks/htc-datascience-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-datascience-notebook/entrypoint.sh
+++ b/notebooks/htc-datascience-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/minimal-notebook:latest
+FROM jupyter/minimal-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-minimal-notebook/Dockerfile
+++ b/notebooks/htc-minimal-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-minimal-notebook/condor_config.local
+++ b/notebooks/htc-minimal-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-minimal-notebook/entrypoint.sh
+++ b/notebooks/htc-minimal-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-pyspark-notebook/Dockerfile
+++ b/notebooks/htc-pyspark-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/pyspark-notebook:latest
+FROM jupyter/pyspark-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-pyspark-notebook/condor_config.local
+++ b/notebooks/htc-pyspark-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-pyspark-notebook/entrypoint.sh
+++ b/notebooks/htc-pyspark-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-r-notebook/Dockerfile
+++ b/notebooks/htc-r-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/r-notebook:latest
+FROM jupyter/r-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-r-notebook/condor_config.local
+++ b/notebooks/htc-r-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-r-notebook/entrypoint.sh
+++ b/notebooks/htc-r-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/scipy-notebook:latest
+FROM jupyter/scipy-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-scipy-notebook/Dockerfile
+++ b/notebooks/htc-scipy-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-scipy-notebook/condor_config.local
+++ b/notebooks/htc-scipy-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-scipy-notebook/entrypoint.sh
+++ b/notebooks/htc-scipy-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/notebooks/htc-tensorflow-notebook/Dockerfile
+++ b/notebooks/htc-tensorflow-notebook/Dockerfile
@@ -7,13 +7,10 @@
 # Copyright (C) HTCondor Team, Computer Sciences Dept, Univ of Wisconsin-Madison
 # Distributed under terms of the Apache Licence, Version 2.0.
 
-FROM jupyter/tensorflow-notebook:latest
+FROM jupyter/tensorflow-notebook:ubuntu-20.04
 
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
-
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
 
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/notebooks/htc-tensorflow-notebook/condor_config.local
+++ b/notebooks/htc-tensorflow-notebook/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/notebooks/htc-tensorflow-notebook/entrypoint.sh
+++ b/notebooks/htc-tensorflow-notebook/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -12,9 +12,6 @@ FROM <BASE_IMAGE>
 # metadata
 LABEL maintainer="chtc@cs.wisc.edu"
 
-# select HTCondor release series (first two parts only!)
-ARG HTCONDOR_VERSION=9.x
-
 # default to jupyter lab
 ENV JUPYTER_ENABLE_LAB=1
 
@@ -29,13 +26,12 @@ COPY entrypoint.sh /.entrypoint.sh
 # install HTCondor, and a few other convenience tools
 # also fix permissions on the files copied above
 RUN apt-get update -y \
- && apt-get install -y gnupg vim less git man \
- && wget -qO - https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-${HTCONDOR_VERSION}-Key | apt-key add - \
- && echo "deb  https://research.cs.wisc.edu/htcondor/repo/ubuntu/${HTCONDOR_VERSION} focal main" >> /etc/apt/sources.list \
- && apt-get update -y \
- && apt-get install -y htcondor \
+ && apt-get upgrade -y \
+ && apt-get install -y curl git gnupg less man vim wget \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
+ #
+ && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -47,7 +47,10 @@ RUN apt-get update -y \
 USER $NB_UID:$NB_GID
 
 # install HTCondor Python bindings, HTChirp, and HTMap
-RUN pip install --no-cache-dir htcondor htchirp htmap
+RUN pip install --no-cache-dir \
+      htchirp \
+      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htmap
 
 # set up environment variable hooks for HTMap settings
 # todo: once HTMap can decide the delivery method itself, remove it from here!

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -31,7 +31,15 @@ RUN apt-get update -y \
  && apt-get clean -y \
  && rm -rf /var/lib/apt/lists/* \
  #
+ # Install HTCondor. Immediately stop the pool in case the installation
+ # script automatically started it.
+ #
  && curl -fsSL https://get.htcondor.org | /bin/bash -s -- --no-dry-run \
+ && condor_off -master \
+ && sleep 5 \
+ #
+ # Fix permissions on various files and directories.
+ #
  && chmod +x /.entrypoint.sh \
  && chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/.condor \
  && fix-permissions ${HOME}

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -49,7 +49,7 @@ USER $NB_UID:$NB_GID
 # install HTCondor Python bindings, HTChirp, and HTMap
 RUN pip install --no-cache-dir \
       htchirp \
-      htcondor==$(condor_version | head -n1 | cut -d " " -f 2) \
+      htcondor'>'=$(condor_version | head -n1 | cut -d " " -f 2) \
       htmap
 
 # set up environment variable hooks for HTMap settings

--- a/template/condor_config.local
+++ b/template/condor_config.local
@@ -1,9 +1,3 @@
-# We want a 'personal condor'
-CONDOR_HOST = $(IP_ADDRESS)
-use ROLE: CentralManager
-use ROLE: Submit
-use ROLE: Execute
-
 # Edit paths so all state gets stored in user home directory
 LOCAL_DIR=$ENV(HOME)/.condor/local
 LOCK=$(LOCAL_DIR)/lock
@@ -12,15 +6,6 @@ RUN=$(LOCAL_DIR)/run
 SPOOL=$(LOCAL_DIR)/spool
 EXECUTE=$(LOCAL_DIR)/execute
 CRED_STORE_DIR=$(LOCAL_DIR)/cred_dir
-
-# Tuning so jobs start quickly
-SCHEDD_INTERVAL=5
-NEGOTIATOR_INTERVAL=2
-NEGOTIATOR_CYCLE_DELAY=5
-STARTER_UPDATE_INTERVAL=5
-SHADOW_QUEUE_UPDATE_INTERVAL=10
-UPDATE_INTERVAL=5
-RUNBENCHMARKS=0
 
 # Put all of the machine resources under a single partitionable slot
 NUM_SLOTS = 1

--- a/template/entrypoint.sh
+++ b/template/entrypoint.sh
@@ -31,4 +31,9 @@ fi
 
 echo $_MSG
 
+# Allow derived images to run additional runtime customizations.
+shopt -s nullglob
+for x in /image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
 exec "$@"


### PR DESCRIPTION
1. The "base" images have been pinned to Ubuntu 20.04. This is necessary until HTCondor is released for Ubuntu 22.04.

2. The `Dockerfile` has been updated to install HTCondor using https://get.htcondor.org. Going forward, this eliminates the need to update the file each time a new major release comes out.

3. Derived images and containers can now put additional initialization scripts in `/image-init.d`, similar to [OSG's software base image](https://github.com/opensciencegrid/docker-software-base).